### PR TITLE
Ensuring food is placed on grid

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5,8 +5,8 @@
 Game::Game(std::size_t grid_width, std::size_t grid_height)
     : snake(grid_width, grid_height),
       engine(dev()),
-      random_w(0, static_cast<int>(grid_width)),
-      random_h(0, static_cast<int>(grid_height)) {
+      random_w(0, static_cast<int>(grid_width - 1)),
+      random_h(0, static_cast<int>(grid_height - 1)) {
   PlaceFood();
 }
 


### PR DESCRIPTION
The random generator for x and y could generate food places which are outside of the grid because it generates from 0 to 32 inclusive. However 32 should not be included.